### PR TITLE
Fix error with ed25519 ssh keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ all:
 	find config/ -type f -print0 | xargs -0 sed -i 's/%%SYNAPSE_MACAROON_SECRET_KEY%%/${SYNAPSE_MACAROON_SECRET_KEY}/'
 	find config/ -type f -print0 | xargs -0 sed -i 's/%%SYNAPSE_FORM_SECRET%%/${SYNAPSE_FORM_SECRET}/'
 	echo ${SYNAPSE_SIGNING_KEY} > config/synapse/synapse.signing.key
-	sed 's/%%SSH_PUBKEY%%/${SSH_PUBKEY}/' config.yaml | fcct --files-dir config --strict --output config.ign
+	sed 's|%%SSH_PUBKEY%%|${SSH_PUBKEY}|' config.yaml | fcct --files-dir config --strict --output config.ign


### PR DESCRIPTION
The ssh contains a '/' which results in the following error message:

    sed: -e expression #1, char 85: unknown option to `s'
    Error translating config: error parsing variant; must be specified
    make: *** [Makefile:15: all] Error 1