### PR TITLE
Remove cgroupsv2 migration (now default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ If you already have certificates from Let's Encrypt or another provider, see
 the [in progress PR](https://github.com/travier/fedora-coreos-matrix/pull/10)
 for an alternative with existing certificates.
 
-
 ## How to use
 
-To generate the Ignition configs, you need `make` and `fcct`.
+To generate the Ignition configs, you need `make` and [Butane][butane]:
 
 Then, you need to provide values for each variable in the secrets file:
 
@@ -202,3 +201,4 @@ $ rm -rf /var/srv/matrix/postgres.dump /var/srv/matrix/postgres.bak
 [deploy]: https://docs.fedoraproject.org/en-US/fedora-coreos/getting-started/
 [plugins]: https://certbot.eff.org/docs/using.html#dns-plugins
 [updates]: https://coreos.github.io/zincati/usage/updates-strategy/#periodic-strategy
+[butane]: https://coreos.github.io/butane/getting-started/#getting-butane

--- a/config.bu
+++ b/config.bu
@@ -8,35 +8,13 @@ passwd:
 
 systemd:
   units:
-    - name: cgroups-v2-karg.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Switch To cgroups v2 and disable Docker
-        # We run after `systemd-machine-id-commit.service` to ensure that
-        # `ConditionFirstBoot=true` services won't rerun on the next boot.
-        After=systemd-machine-id-commit.service
-        ConditionKernelCommandLine=systemd.unified_cgroup_hierarchy
-        ConditionPathExists=!/var/lib/cgroups-v2-karg.stamp
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStart=/bin/systemctl disable --now docker.socket
-        ExecStart=/bin/rpm-ostree kargs --delete=systemd.unified_cgroup_hierarchy
-        ExecStart=/bin/touch /var/lib/cgroups-v2-karg.stamp
-        ExecStart=/bin/systemctl --no-block reboot
-
-        [Install]
-        WantedBy=multi-user.target
-
     - name: pod-matrix.service
       enabled: true
       contents: |
         [Unit]
         Description=Creates a podman pod to run the matrix services.
-        After=cgroups-v2-karg.service network-online.target
-        Wants=cgroups-v2-karg.service network-online.target
+        After=network-online.target
+        Wants=network-online.target
 
         [Service]
         Type=oneshot

--- a/config.bu
+++ b/config.bu
@@ -178,8 +178,8 @@ systemd:
             --conmon-pidfile %t/container-nginx-http.pid \
             --cidfile %t/container-nginx-http.ctr-id \
             --cgroups=no-conmon -d --replace \
-            --rm \
             --pull=always \
+            --rm \
             --read-only \
             --pod=matrix \
             --name=nginx-http \
@@ -213,8 +213,8 @@ systemd:
             --conmon-pidfile %t/container-element-web.pid \
             --cidfile %t/container-element-web.ctr-id \
             --cgroups=no-conmon -d --replace \
-            --rm \
             --pull=always \
+            --rm \
             --read-only \
             --pod=matrix \
             --name=element-web \


### PR DESCRIPTION
config: Remove cgroupsv2 migration (now default)

---

config: Always order '--rm' after '--pull=always'